### PR TITLE
chore(cli): consistent print output

### DIFF
--- a/crates/cli/src/commands/credentials.rs
+++ b/crates/cli/src/commands/credentials.rs
@@ -3,7 +3,6 @@
 use nexum_apdu_transport_pcsc::PcscTransport;
 use nexum_keycard::CredentialType;
 use std::error::Error;
-use tracing::debug;
 
 use crate::utils;
 
@@ -55,12 +54,6 @@ pub fn unblock_pin_command(
 
     // Initialize keycard with pairing info
     let mut keycard = utils::session::initialize_keycard(transport, Some(pairing_args))?;
-
-    // We need a secure channel for unblocking PIN
-    if !keycard.is_secure_channel_open() && keycard.pairing_info().is_some() {
-        debug!("Opening secure channel");
-        keycard.open_secure_channel()?;
-    }
 
     // Unblock PIN
     keycard.unblock_pin(puk, new_pin, true)?;

--- a/crates/cli/src/commands/data_management.rs
+++ b/crates/cli/src/commands/data_management.rs
@@ -4,7 +4,6 @@ use alloy_primitives::hex;
 use nexum_apdu_transport_pcsc::PcscTransport;
 use nexum_keycard::PersistentRecord;
 use std::error::Error;
-use tracing::debug;
 
 use crate::utils;
 
@@ -39,19 +38,14 @@ pub fn get_data_command(
     // Initialize keycard with pairing info
     let mut keycard = utils::session::initialize_keycard(transport, Some(pairing_args))?;
 
-    // We need a secure channel to get data
-    if !keycard.is_secure_channel_open() && keycard.pairing_info().is_some() {
-        debug!("Opening secure channel");
-        keycard.open_secure_channel()?;
-    }
-
     // Get the data by record type
     let record_label = format!("{:?}", record);
     let data = keycard.get_data(record)?;
 
     println!(
-        "Retrieved data from {} record: {}",
+        "Retrieved data from {} record (length: {} bytes): {}",
         record_label,
+        data.len(),
         hex::encode(&data)
     );
 

--- a/crates/keycard/src/application.rs
+++ b/crates/keycard/src/application.rs
@@ -64,7 +64,7 @@ impl<E: Executor> Keycard<E> {
         let app_info = select_keycard_with_transport(&mut transport)?;
 
         // Get the card's public key - this is required for secure channel
-        let card_public_key = match app_info.public_key.clone() {
+        let card_public_key = match app_info.public_key {
             Some(key) => key,
             None => {
                 return Err(Error::Message(
@@ -123,7 +123,7 @@ impl<E: Executor> Keycard<E> {
 
                     debug!(
                         "Using pairing key and index: {} (index: {})",
-                        hex::encode(&key),
+                        hex::encode(key),
                         index
                     );
 
@@ -135,7 +135,7 @@ impl<E: Executor> Keycard<E> {
         };
 
         // Configure the secure channel with the providers
-        secure_channel.configure_providers(card_public_key.clone(), pairing_provider, pin_provider);
+        secure_channel.configure_providers(card_public_key, pairing_provider, pin_provider);
 
         // Create an executor from the secure channel
         let executor = E::from(CardExecutor::new(secure_channel));

--- a/crates/keycard/src/commands/get_data.rs
+++ b/crates/keycard/src/commands/get_data.rs
@@ -35,6 +35,14 @@ apdu_pair! {
                 #[error("Incorrect P1/P2: The record specified is not valid")]
                 IncorrectP1P2,
             }
+
+            custom_parse = |response: &nexum_apdu_core::Response| -> Result<GetDataOk, GetDataError> {
+                match response.status() {
+                    SW_NO_ERROR => Ok(GetDataOk::Success { data: response.payload().as_ref().unwrap_or(&Bytes::new()).to_vec() }),
+                    SW_INCORRECT_P1P2 => Err(GetDataError::IncorrectP1P2),
+                    _ => Err(GetDataError::Unknown { sw1: response.status().sw1, sw2: response.status().sw2 }),
+                }
+            }
         }
     }
 }

--- a/crates/keycard/src/commands/get_status.rs
+++ b/crates/keycard/src/commands/get_status.rs
@@ -69,7 +69,13 @@ apdu_pair! {
                                     status,
                                 })
                             },
-                            _ => Err(GetStatusError::IncorrectP1P2),
+                            // When it is currently the master key, there is no derivation path, therefore
+                            // there will be no payload returned.
+                            None => {
+                                Ok(GetStatusOk::KeyPathStatus {
+                                    path: DerivationPath::default(),
+                                })
+                            }
                         }
                     }
                     SW_INCORRECT_P1P2 => Err(GetStatusError::IncorrectP1P2),

--- a/crates/keycard/src/types/application_info.rs
+++ b/crates/keycard/src/types/application_info.rs
@@ -73,25 +73,22 @@ impl fmt::Display for ApplicationInfo {
         writeln!(f, "Application Info:")?;
         writeln!(f, "  Instance UID: {}", hex::encode(self.instance_uid))?;
 
-        if let Some(ref public_key) = self.public_key {
-            writeln!(
-                f,
-                "  Public Key: {}",
-                public_key.to_sec1_bytes().encode_hex_with_prefix()
-            )?;
-        } else {
-            writeln!(f, "  Public Key: None")?;
-        }
-
         writeln!(f, "  Version: {}", self.version)?;
-        writeln!(f, "  Remaining Slots: {}", self.remaining_slots)?;
+        writeln!(f, "  Remaining pairing slots: {}", self.remaining_slots)?;
 
         if let Some(ref key_uid) = self.key_uid {
             writeln!(f, "  Key UID: {}", key_uid.encode_hex_with_prefix())?;
         } else {
-            writeln!(f, "  Key UID: None")?;
+            writeln!(f, "  Key UID: None (Use GENERATE KEY)")?;
         }
 
-        write!(f, "  Capabilities: {}", self.capabilities)
+        writeln!(f, "  Capabilities: {}", self.capabilities)?;
+
+        write!(f, "  Secure channel public key: ")?;
+        if let Some(ref public_key) = self.public_key {
+            write!(f, "{}", public_key.to_sec1_bytes().encode_hex_with_prefix())
+        } else {
+            write!(f, "None")
+        }
     }
 }

--- a/crates/keycard/src/types/application_status.rs
+++ b/crates/keycard/src/types/application_status.rs
@@ -56,6 +56,6 @@ impl fmt::Display for ApplicationStatus {
         writeln!(f, "Application Status:")?;
         writeln!(f, "  PIN retries remaining: {}", self.pin_retry_count)?;
         writeln!(f, "  PUK retries remaining: {}", self.puk_retry_count)?;
-        writeln!(f, "  Key initialized: {}", self.key_initialized)
+        write!(f, "  Key initialized: {}", self.key_initialized)
     }
 }


### PR DESCRIPTION
This PR:

1. Fixes #6 by utilising the `Display` trait implementations for the respective structs correctly instead of repeating this.
2. Fixes some errors with the `GET STATUS` and `GET DATA` commands whereby the yielding of 0 length payloads is a valid result (for example when the key derivation path is length 0, and when the data stored in a record is 0 bytes in length).