### PR TITLE
chore(cli): unify derivation options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
+ "coins-bip32",
  "nexum-apdu-core",
  "nexum-keycard",
  "parking_lot",

--- a/crates/cli/src/commands/key_operations.rs
+++ b/crates/cli/src/commands/key_operations.rs
@@ -60,7 +60,7 @@ pub fn export_key_command(
         );
         println!(
             "Ethereum address: {}",
-            Address::from_public_key(&public_key.into()).to_string()
+            Address::from_public_key(&public_key.into())
         );
     }
 

--- a/crates/cli/src/commands/key_operations.rs
+++ b/crates/cli/src/commands/key_operations.rs
@@ -1,5 +1,6 @@
 //! Commands for key management operations
 
+use alloy_primitives::Address;
 use alloy_primitives::hex::{self, ToHexExt};
 use coins_bip32::path::DerivationPath;
 use nexum_apdu_transport_pcsc::PcscTransport;
@@ -14,7 +15,6 @@ use crate::utils;
 pub fn generate_key_command(
     transport: PcscTransport,
     pairing_args: &utils::PairingArgs,
-    _path: Option<&String>,
 ) -> Result<(), Box<dyn Error>> {
     // Initialize keycard with pairing info
     let mut keycard = utils::session::initialize_keycard(transport, Some(pairing_args))?;
@@ -33,30 +33,34 @@ pub fn generate_key_command(
 pub fn export_key_command(
     transport: PcscTransport,
     pairing_args: &utils::PairingArgs,
-    path: Option<&String>,
+    derivation_args: &utils::DerivationArgs,
+    export_option: ExportOption,
 ) -> Result<(), Box<dyn Error>> {
     // Initialize keycard with pairing info
     let mut keycard = utils::session::initialize_keycard(transport, Some(pairing_args))?;
 
+    // Parse the derivation path
+    let path = derivation_args.parse_derivation_path()?;
+    info!("Exporting key with path: {}", derivation_args.path_string());
+
     // Export the key
-    let keypair = if let Some(derivation_path) = path {
-        info!("Exporting key with path: {}", derivation_path);
-        // Parse the derivation path
-        let path = DerivationPath::from_str(derivation_path)?;
-        keycard.export_key_from_master(ExportOption::PrivateAndPublic, Some(&path), false, true)?
-    } else {
-        info!("Exporting current key");
-        keycard.export_key(ExportOption::PrivateAndPublic)?
-    };
+    let keypair = keycard.export_key(export_option, &path)?;
 
     // Display the key information
-    println!("Key exported successfully");
+    println!(
+        "Key at path {} exported successfully",
+        path.derivation_string()
+    );
 
     // Display public key if available
     if let Some(public_key) = keypair.public_key() {
         println!(
             "Public key: 0x{}",
             hex::encode(public_key.to_sec1_bytes().as_ref())
+        );
+        println!(
+            "Ethereum address: {}",
+            Address::from_public_key(&public_key.into()).to_string()
         );
     }
 
@@ -77,7 +81,7 @@ pub fn export_key_command(
 pub async fn sign_command(
     transport: PcscTransport,
     data: &str,
-    path: Option<&String>,
+    derivation_args: &utils::DerivationArgs,
     pairing_args: &utils::PairingArgs,
 ) -> Result<(), Box<dyn Error>> {
     // Parse the data from hex
@@ -86,25 +90,15 @@ pub async fn sign_command(
     // Initialize keycard with pairing info
     let mut keycard = utils::session::initialize_keycard(transport, Some(pairing_args))?;
 
-    // Sign the data
-    let signature = if let Some(derivation_path_str) = path {
-        let derivation_path = DerivationPath::from_str(derivation_path_str)?;
-        info!(
-            "Signing with key at path: {}",
-            derivation_path.derivation_string()
-        );
-        // In this case, just sign with current key
-        // The actual path derivation is handled internally by the keycard
-        // and we are not passing a KeyPath object directly
-        keycard.sign(
-            &data_bytes,
-            nexum_keycard::KeyPath::FromMaster(Some(derivation_path)),
-            false,
-        )?
-    } else {
-        info!("Signing with current key");
-        keycard.sign(&data_bytes, nexum_keycard::KeyPath::Current, false)?
-    };
+    // Parse the derivation path
+    let derivation_path = derivation_args.parse_derivation_path()?;
+    info!(
+        "Signing with key at path: {}",
+        derivation_args.path_string()
+    );
+
+    // The actual path derivation is handled internally by the keycard
+    let signature = keycard.sign(&data_bytes, &derivation_path, true)?;
 
     // Display the signature
     println!(

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -55,10 +55,6 @@ pub enum Commands {
         /// Pairing info for secure channel
         #[command(flatten)]
         pairing: crate::utils::PairingArgs,
-
-        /// Optional derivation path (e.g. m/44'/60'/0'/0/0)
-        #[arg(long)]
-        path: Option<String>,
     },
 
     /// Export the current key from the card
@@ -67,9 +63,13 @@ pub enum Commands {
         #[command(flatten)]
         pairing: crate::utils::PairingArgs,
 
-        /// Optional derivation path (e.g. m/44'/60'/0'/0/0)
-        #[arg(long)]
-        path: Option<String>,
+        /// Derivation path arguments
+        #[command(flatten)]
+        derivation: crate::utils::DerivationArgs,
+
+        /// Export option (what parts of the key to export)
+        #[arg(long = "export-option", value_enum, default_value_t = nexum_keycard::ExportOption::PublicKeyOnly)]
+        export_option: nexum_keycard::ExportOption,
     },
 
     /// Sign data with the current key
@@ -78,9 +78,9 @@ pub enum Commands {
         #[arg(required = true)]
         data: String,
 
-        /// Optional derivation path (e.g. m/44'/60'/0'/0/0)
-        #[arg(long)]
-        path: Option<String>,
+        /// Derivation path arguments
+        #[command(flatten)]
+        derivation: crate::utils::DerivationArgs,
 
         /// Pairing info for secure channel
         #[command(flatten)]
@@ -118,8 +118,8 @@ pub enum Commands {
 
     /// Set a PIN-less path for signature operations
     SetPinlessPath {
-        /// Derivation path (e.g. m/44'/60'/0'/0/0)
-        #[arg(required = true)]
+        /// Derivation path (e.g. m/44'/60'/0'/0/0) - required for this command
+        #[arg(long, required = true)]
         path: String,
 
         /// Pairing info for secure channel

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -67,17 +67,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     commands::init_command(transport, pin, puk, pairing_password, output.as_ref())?
                 }
                 Commands::Pair { output } => commands::pair_command(transport, output.as_ref())?,
-                Commands::GenerateKey { pairing, path } => {
-                    commands::generate_key_command(transport, pairing, path.as_ref())?
+                Commands::GenerateKey { pairing } => {
+                    commands::generate_key_command(transport, pairing)?
                 }
-                Commands::ExportKey { pairing, path } => {
-                    commands::export_key_command(transport, pairing, path.as_ref())?
-                }
+                Commands::ExportKey {
+                    pairing,
+                    derivation,
+                    export_option,
+                } => commands::export_key_command(transport, pairing, derivation, *export_option)?,
                 Commands::Sign {
                     data,
-                    path,
+                    derivation,
                     pairing,
-                } => commands::sign_command(transport, data, path.as_ref(), pairing).await?,
+                } => commands::sign_command(transport, data, derivation, pairing).await?,
                 Commands::ChangeCredential {
                     credential_type,
                     new_value,
@@ -114,12 +116,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     record_type,
                     data,
                     pairing,
-                } => commands::store_data_command(
-                    transport,
-                    *record_type,
-                    data.as_bytes(),
-                    pairing,
-                )?,
+                } => {
+                    commands::store_data_command(transport, *record_type, data.as_bytes(), pairing)?
+                }
                 Commands::GetData {
                     record_type,
                     pairing,

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -12,6 +12,29 @@ use std::error::Error;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::str::FromStr;
+use coins_bip32::path::DerivationPath;
+
+/// Arguments for derivation path
+#[derive(Args, Debug, Clone)]
+pub struct DerivationArgs {
+    /// Derivation path (e.g. m/44'/60'/0'/0/0)
+    #[arg(long, default_value = "m/44'/60'/0'/0/0")]
+    pub path: String,
+}
+
+impl DerivationArgs {
+    /// Parse the derivation path
+    pub fn parse_derivation_path(&self) -> Result<DerivationPath, Box<dyn Error>> {
+        let path = DerivationPath::from_str(&self.path)?;
+        Ok(path)
+    }
+    
+    /// Get the path string representation
+    pub fn path_string(&self) -> &str {
+        &self.path
+    }
+}
 
 /// Common arguments for pairing information
 #[derive(Args, Debug, Clone)]

--- a/crates/keycard/src/application.rs
+++ b/crates/keycard/src/application.rs
@@ -449,138 +449,9 @@ where
     /// - `ExportOption::PrivateAndPublic` → Returns `ExportedKey::Complete`
     /// - `ExportOption::PublicKeyOnly` → Returns `ExportedKey::PublicOnly`
     /// - `ExportOption::ExtendedPublicKey` → Returns `ExportedKey::Extended`
-    pub fn export_key(&mut self, what: ExportOption) -> Result<ExportedKey> {
+    pub fn export_key(&mut self, what: ExportOption, path: &DerivationPath) -> Result<ExportedKey> {
         // Create command to export current key
-        let cmd = ExportKeyCommand::from_current(what)?;
-
-        // Execute the command
-        let response = self.executor.execute_secure(&cmd)?;
-
-        // Extract the keypair from the response
-        let ExportKeyOk::Success { keypair } = response;
-
-        // Convert to appropriate ExportedKey type based on what was requested
-        ExportedKey::try_from_keypair(keypair, what)
-    }
-
-    /// Export a key derived from the master key
-    ///
-    /// Returns an `ExportedKey` enum which contains the key data in a format that matches
-    /// the requested export option:
-    /// - `ExportOption::PrivateAndPublic` → Returns `ExportedKey::Complete`
-    /// - `ExportOption::PublicKeyOnly` → Returns `ExportedKey::PublicOnly`
-    /// - `ExportOption::ExtendedPublicKey` → Returns `ExportedKey::Extended`
-    pub fn export_key_from_master(
-        &mut self,
-        what: ExportOption,
-        path: Option<&DerivationPath>,
-        make_current: bool,
-        confirm: bool,
-    ) -> Result<ExportedKey> {
-        if make_current
-            && confirm
-            && !self.confirm_operation("Make the key derived from master the current key?")
-        {
-            return Err(Error::UserCancelled);
-        }
-
-        // Create command to export key derived from master
-        let cmd = ExportKeyCommand::from_master(what, path, make_current)?;
-
-        // Execute the command
-        let response = self.executor.execute_secure(&cmd)?;
-
-        // Extract the keypair from the response
-        let ExportKeyOk::Success { keypair } = response;
-
-        // Convert to appropriate ExportedKey type based on what was requested
-        ExportedKey::try_from_keypair(keypair, what)
-    }
-
-    /// Export a key derived from the parent key
-    ///
-    /// Returns an `ExportedKey` enum which contains the key data in a format that matches
-    /// the requested export option:
-    /// - `ExportOption::PrivateAndPublic` → Returns `ExportedKey::Complete`
-    /// - `ExportOption::PublicKeyOnly` → Returns `ExportedKey::PublicOnly`
-    /// - `ExportOption::ExtendedPublicKey` → Returns `ExportedKey::Extended`
-    pub fn export_key_from_parent(
-        &mut self,
-        what: ExportOption,
-        path: &DerivationPath,
-        make_current: bool,
-        confirm: bool,
-    ) -> Result<ExportedKey> {
-        if make_current && confirm && !self.confirm_operation("Make derived key current?") {
-            return Err(Error::UserCancelled);
-        }
-
-        // Create command to export key derived from parent
-        let cmd = ExportKeyCommand::from_parent(what, path, make_current)?;
-
-        // Execute the command
-        let response = self.executor.execute_secure(&cmd)?;
-
-        // Extract the keypair from the response
-        let ExportKeyOk::Success { keypair } = response;
-
-        // Convert to appropriate ExportedKey type based on what was requested
-        ExportedKey::try_from_keypair(keypair, what)
-    }
-
-    /// Export a key derived from the current key
-    ///
-    /// Returns an `ExportedKey` enum which contains the key data in a format that matches
-    /// the requested export option:
-    /// - `ExportOption::PrivateAndPublic` → Returns `ExportedKey::Complete`
-    /// - `ExportOption::PublicKeyOnly` → Returns `ExportedKey::PublicOnly`
-    /// - `ExportOption::ExtendedPublicKey` → Returns `ExportedKey::Extended`
-    pub fn export_key_from_current(
-        &mut self,
-        what: ExportOption,
-        path: &DerivationPath,
-        make_current: bool,
-        confirm: bool,
-    ) -> Result<ExportedKey> {
-        if make_current && confirm && !self.confirm_operation("Make derived key current?") {
-            return Err(Error::UserCancelled);
-        }
-
-        // Create command to export key derived from current
-        let cmd = ExportKeyCommand::from_current_with_derivation(what, path, make_current)?;
-
-        // Execute the command
-        let response = self.executor.execute_secure(&cmd)?;
-
-        // Extract the keypair from the response
-        let ExportKeyOk::Success { keypair } = response;
-
-        // Convert to appropriate ExportedKey type based on what was requested
-        ExportedKey::try_from_keypair(keypair, what)
-    }
-
-    /// Export a key with full control over derivation options (legacy method)
-    ///
-    /// Returns an `ExportedKey` enum which contains the key data in a format that matches
-    /// the requested export option:
-    /// - `ExportOption::PrivateAndPublic` → Returns `ExportedKey::Complete`
-    /// - `ExportOption::PublicKeyOnly` → Returns `ExportedKey::PublicOnly`
-    /// - `ExportOption::ExtendedPublicKey` → Returns `ExportedKey::Extended`
-    pub fn export_key_with_options(
-        &mut self,
-        what: ExportOption,
-        key_path: &KeyPath,
-        derive_mode: Option<DeriveMode>,
-    ) -> Result<ExportedKey> {
-        if let Some(DeriveMode::Persistent) = derive_mode {
-            let confirmed = self.confirm_operation("Make derived key current?");
-            if !confirmed {
-                return Err(Error::Message("Operation cancelled".to_string()));
-            }
-        }
-
-        // Create the export key command
-        let cmd = ExportKeyCommand::with(what, key_path, derive_mode)?;
+        let cmd = ExportKeyCommand::from_path(what, path);
 
         // Execute the command
         let response = self.executor.execute_secure(&cmd)?;
@@ -596,20 +467,16 @@ where
     pub fn sign(
         &mut self,
         data: &[u8],
-        key_path: KeyPath,
+        path: &DerivationPath,
         confirm: bool,
     ) -> Result<alloy_primitives::Signature> {
-        // Create description for confirmation
-        let path_str = match &key_path {
-            KeyPath::Current => "current key".to_string(),
-            KeyPath::FromMaster(Some(path)) => format!("master key with path {:?}", path),
-            KeyPath::FromMaster(None) => "master key".to_string(),
-            KeyPath::FromParent(path) => format!("parent key with path {:?}", path),
-            KeyPath::FromCurrent(path) => format!("current key with path {:?}", path),
-        };
-
         // Confirm the operation if a confirmation function is provided
-        if confirm && !self.confirm_operation(&format!("Sign data using {}?", path_str)) {
+        if confirm
+            && !self.confirm_operation(&format!(
+                "Sign data with key from path {}?",
+                path.derivation_string()
+            ))
+        {
             return Err(Error::UserCancelled);
         }
 
@@ -622,14 +489,8 @@ where
             .try_into()
             .map_err(|_| Error::InvalidData("Failed to convert data to 32-byte array"))?;
 
-        // If KeyPath is Current or FromCurrent variant, we should set the derive_mode parameter to None.
-        let derive_mode = match key_path {
-            KeyPath::Current | KeyPath::FromCurrent(_) => None,
-            _ => Some(DeriveMode::Temporary),
-        };
-
         // Create sign command
-        let cmd = SignCommand::with(&data_array, &key_path, derive_mode)?;
+        let cmd = SignCommand::with(&data_array, &path)?;
 
         // Execute the command
         let SignOk::Success { signature } = self.executor.execute_secure(&cmd)?;

--- a/crates/keycard/src/application.rs
+++ b/crates/keycard/src/application.rs
@@ -490,7 +490,7 @@ where
             .map_err(|_| Error::InvalidData("Failed to convert data to 32-byte array"))?;
 
         // Create sign command
-        let cmd = SignCommand::with(&data_array, &path)?;
+        let cmd = SignCommand::with(&data_array, path)?;
 
         // Execute the command
         let SignOk::Success { signature } = self.executor.execute_secure(&cmd)?;

--- a/crates/keycard/src/commands/derive_key.rs
+++ b/crates/keycard/src/commands/derive_key.rs
@@ -1,8 +1,7 @@
-use bytes::Bytes;
 use nexum_apdu_globalplatform::constants::status::*;
 use nexum_apdu_macros::apdu_pair;
 
-use super::{CLA_GP, DeriveMode, KeyPath, prepare_derivation_parameters};
+use super::CLA_GP;
 
 apdu_pair! {
     /// DERIVE KEY command for Keycard
@@ -11,19 +10,6 @@ apdu_pair! {
             cla: CLA_GP,
             ins: 0xD1,
             required_security_level: SecurityLevel::mac_protected(),
-
-            builders {
-                /// Create a DERIVE_KEY command with the specified parameters.
-                pub fn with(key_path: &KeyPath, derive_mode: Option<DeriveMode>) -> Result<Self, crate::Error> {
-                    let (p1, data) = prepare_derivation_parameters(key_path, derive_mode)?;
-                    let command = Self::new(p1, 0x00).with_le(0);
-
-                    Ok(match data {
-                        Some(data) => command.with_data(Bytes::from(data)),
-                        None => command,
-                    })
-                }
-            }
         }
 
         response {

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -17,6 +17,7 @@ alloy-consensus.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
 parking_lot.workspace = true
+coins-bip32.workspace = true
 
 ## keycard
 nexum-keycard.workspace = true

--- a/crates/signer/src/signer.rs
+++ b/crates/signer/src/signer.rs
@@ -2,11 +2,12 @@ use std::sync::Arc;
 
 use alloy_consensus::SignableTransaction;
 use alloy_network::{AnyNetwork, EthereumWallet, IntoWallet};
-use alloy_primitives::{Address, B256, ChainId, Signature, address};
+use alloy_primitives::{Address, B256, ChainId, Signature};
 use alloy_signer::{Result, Signer, sign_transaction_with_chain_id};
 use async_trait::async_trait;
+use coins_bip32::path::DerivationPath;
 use nexum_apdu_core::prelude::*;
-use nexum_keycard::{KeyPath, Keycard, KeycardSecureChannel};
+use nexum_keycard::{ExportOption, Keycard, KeycardSecureChannel};
 use tokio::sync::Mutex;
 
 // Temporary remove Debug derive since Keycard doesn't implement Debug
@@ -17,6 +18,7 @@ where
     inner: Arc<Mutex<Keycard<CardExecutor<KeycardSecureChannel<T>>>>>,
     pub(crate) chain_id: Option<ChainId>,
     pub(crate) address: Address,
+    pub(crate) derivation_path: DerivationPath,
 }
 
 impl<T> std::fmt::Debug for KeycardSigner<T>
@@ -26,6 +28,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KeycardSigner")
             .field("chain_id", &self.chain_id)
+            .field("derivation_path", &self.derivation_path.derivation_string())
             .field("address", &self.address)
             .finish_non_exhaustive()
     }
@@ -35,13 +38,21 @@ impl<T> KeycardSigner<T>
 where
     T: CardTransport,
 {
-    pub fn new(keycard: Arc<Mutex<Keycard<CardExecutor<KeycardSecureChannel<T>>>>>) -> Self {
-        let address = address!("0xf888b1c80d40c08e53e4f3446ae2dac72fe0f31c");
-        Self {
+    pub async fn new(
+        keycard: Arc<Mutex<Keycard<CardExecutor<KeycardSecureChannel<T>>>>>,
+        path: DerivationPath,
+    ) -> Result<Self> {
+        let address = keycard
+            .lock()
+            .await
+            .export_key(ExportOption::PublicKeyOnly, &path)
+            .map_err(|e| alloy_signer::Error::Other(Box::new(e)))?;
+        Ok(Self {
             inner: keycard,
             chain_id: None,
-            address,
-        }
+            address: Address::from_public_key(&address.public_key().unwrap().into()),
+            derivation_path: path,
+        })
     }
 }
 
@@ -60,7 +71,7 @@ where
             .inner
             .lock()
             .await
-            .sign(data_bytes, KeyPath::Current, false)
+            .sign(data_bytes, &self.derivation_path, false)
             .map_err(|e| alloy_signer::Error::Other(Box::new(e)))?;
 
         Ok(signature)

--- a/crates/signer/src/signer.rs
+++ b/crates/signer/src/signer.rs
@@ -66,7 +66,7 @@ where
         let address = keycard
             .lock()
             .await
-            .export_key(ExportOption::PublicKeyOnly, &path)
+            .export_key(ExportOption::PublicKeyOnly, path)
             .map_err(|e| alloy_signer::Error::Other(Box::new(e)))?;
         Ok(Address::from_public_key(
             &address


### PR DESCRIPTION
This PR:

1. Fixes #8 - the `DERIVE KEY` command will not be used in the CLI, and all `EXPORT KEY` and `SIGN` commands default to a sane derivation path and are configured to derive keys from the master seed on every invocation.
2. In completing #8, incidentally this fixes #14 as the derivation path is now configured when creating the signer and then has the Ethereum address exported from the card to store in a local variable.