### PR TITLE
feat(cli): factory reset

### DIFF
--- a/crates/cli/src/commands/card_operations.rs
+++ b/crates/cli/src/commands/card_operations.rs
@@ -138,7 +138,7 @@ pub fn get_status_command(
 
 /// Factory reset the card
 pub fn factory_reset_command(transport: PcscTransport) -> Result<(), Box<dyn Error>> {
-    // Initialize keycard with pairing info
+    // Initialize keycard with no pairing info (no secure channel / pairing required for FACTORY RESET)
     let mut keycard = utils::session::initialize_keycard(transport, None)?;
 
     // Factory reset the card

--- a/crates/cli/src/commands/card_operations.rs
+++ b/crates/cli/src/commands/card_operations.rs
@@ -128,12 +128,21 @@ pub fn get_status_command(
     // Given that can get pairing information, we can fetch all the data
     let application_info = keycard.select_keycard()?;
     let application_status = keycard.get_status()?;
-    let path = keycard.get_key_path()?;
 
     // Display the information we have fetched
     println!("{}", application_info);
     println!("{}", application_status);
-    println!("  Current key path: {}", path.derivation_string());
+
+    Ok(())
+}
+
+/// Factory reset the card
+pub fn factory_reset_command(transport: PcscTransport) -> Result<(), Box<dyn Error>> {
+    // Initialize keycard with pairing info
+    let mut keycard = utils::session::initialize_keycard(transport, None)?;
+
+    // Factory reset the card
+    keycard.factory_reset(true)?;
 
     Ok(())
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -202,6 +202,9 @@ pub enum Commands {
         #[command(flatten)]
         pairing: crate::utils::PairingArgs,
     },
+
+    /// Factory reset the card
+    FactoryReset,
 }
 
 /// List all available readers

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -123,6 +123,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     record_type,
                     pairing,
                 } => commands::get_data_command(transport, *record_type, pairing)?,
+                Commands::FactoryReset => commands::factory_reset_command(transport)?,
             }
         }
     }

--- a/crates/keycard/src/application.rs
+++ b/crates/keycard/src/application.rs
@@ -566,6 +566,22 @@ where
         Ok(())
     }
 
+    /// Factory reset the card
+    pub fn factory_reset(&mut self, confirm: bool) -> Result<()> {
+        // Confirm the operation if a confirmation function is provided
+        if confirm && !self.confirm_operation("Factory reset the card? This will erase all data.") {
+            return Err(Error::UserCancelled);
+        }
+
+        // Create the factory reset command
+        let cmd = FactoryResetCommand::reset();
+
+        // Execute the command
+        self.executor.execute(&cmd)?;
+
+        Ok(())
+    }
+
     /// Remove the current key from the card
     pub fn remove_key(&mut self, confirm: bool) -> Result<()> {
         // Check if the card supports key management


### PR DESCRIPTION
This PR:

1. Fixes #9 
2. Removes the printing of the current key path in `GET STATUS` as this is no longer relevant given that all signing and exporting of keys are derived from master and are non-permanent.