### PR TITLE
feat(cli): load key from seed phrase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "cipher",
  "clap",
  "coins-bip32",
+ "coins-bip39",
  "iso7816-tlv",
  "nexum-apdu-core",
  "nexum-apdu-globalplatform",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,5 +33,6 @@ tracing.workspace = true
 iso7816-tlv.workspace = true
 tracing-subscriber.workspace = true
 coins-bip32.workspace = true
+coins-bip39 = { workspace = true, features = ["all-langs"] }
 tokio = { workspace = true, features = ["full"] }
 rand = { workspace = true }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -130,10 +130,14 @@ pub enum Commands {
     },
 
     /// Load an existing key onto the card
-    LoadKey {
-        /// BIP39 seed or private key in hex format
-        #[arg(required = true)]
-        seed: String,
+    LoadKeyFromSeed {
+        /// Optional password for seed phrase
+        #[arg(long)]
+        password: bool,
+
+        /// Language for the wordlist
+        #[arg(long, value_parser = ["english", "chinese_simplified", "chinese_traditional", "czech", "french", "italian", "japanese", "korean", "portuguese", "spanish"], default_value = "english")]
+        language: String,
 
         /// Pairing info for secure channel
         #[command(flatten)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -98,9 +98,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 Commands::SetPinlessPath { path, pairing } => {
                     commands::set_pinless_path_command(transport, path, pairing)?
                 }
-                Commands::LoadKey { seed, pairing } => {
-                    commands::load_key_command(transport, seed, pairing)?
-                }
+                Commands::LoadKeyFromSeed {
+                    password,
+                    language,
+                    pairing,
+                } => commands::load_seed_command(transport, *password, &language, pairing)?,
                 Commands::RemoveKey { pairing } => {
                     commands::remove_key_command(transport, pairing)?
                 }


### PR DESCRIPTION
This PR:

1. Fixes #17 - allowing loading seed phrases into the master key on the Keycard.
2. Seed phrase import supports all languages as supported by the `coins-bip39` crate.